### PR TITLE
Some small ESLint configuration improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "rules": {
     // key: 0 = allow, 1 = warn, 2 = error
     "comma-dangle": [0, "always-multiline"],
+    "global-strict": [0],
     "new-cap": [
       2,
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
   "rules": {
     // key: 0 = allow, 1 = warn, 2 = error
     "comma-dangle": [0, "always-multiline"],
-    "strict": [2, "global"],
     "new-cap": [
       2,
       {
@@ -18,6 +17,7 @@
     "no-alert": [0],
     "no-underscore-dangle": [0],
     "no-use-before-define": [0],
-    "quotes": [1, "single", "avoid-escape"]
+    "quotes": [1, "single", "avoid-escape"],
+    "strict": [2, "global"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-jest": "^5.2.0",
     "bluebird": "^2.9.25",
     "classnames": "^2.1.1",
-    "eslint": "^0.20.0",
+    "eslint": "^0.22.0",
     "eslint-plugin-react": "^2.2.0",
     "flux": "^2.0.3",
     "gulp": "^3.8.11",


### PR DESCRIPTION
- Sort alphabetically
- Disable deprecated and noisy `global-strict` rule
- Update ESLint to latest version