### PR TITLE
Make Command+BACKSPACE delete all previous characters

### DIFF
--- a/src/app/components/OmniBar.react.js
+++ b/src/app/components/OmniBar.react.js
@@ -218,8 +218,13 @@ export default class OmniBar extends React.Component {
               // Selection deletion.
               this._pendingDeletion = value.substr(0, selectionStart);
             } else if (selectionStart && event.keyCode === Keys.BACKSPACE) {
-              // Delete last character in field.
-              this._pendingDeletion = value.substr(0, selectionStart - 1);
+              if (event.metaKey) {
+                // Command+BACKSPACE: delete all previous characters in field.
+                this._pendingDeletion = '';
+              } else {
+                // BACKSPACE: delete last character in field.
+                this._pendingDeletion = value.substr(0, selectionStart - 1);
+              }
             } else {
               return; // Nothing to do (already at start of input field).
             }


### PR DESCRIPTION
When interacting with the OmniBar, I noticed that pressing
Command+BACKSPACE when at the end of the line only removed the final
character instead of the expected behavior of removing all of the
previous characters. Oddly, it seemed to behave as expected if the
cursor was not at the very end of the line.

To resolve this, I added a special case for Command+BACKSPACE to clear
all previous characters. I don't have enough context yet to determine if
this is the correct way to solve this problem, or even if it is actually
a problem at all, but it seems like a decent improvement to me.