### PR TITLE
Assume first dir if only one is configured

### DIFF
--- a/lua/corpus/init.lua
+++ b/lua/corpus/init.lua
@@ -91,6 +91,10 @@ corpus = {
       local line = vim.fn.getcmdline()
       local _, _, term = string.find(line, '^%s*Corpus%f[%A]%s*(.-)%s*$')
       if term ~= nil then
+        local num_dirs = table.getn(corpus.directories())
+        if not corpus.in_directory() and num_dirs == 1 then
+          vim.cmd('cd ' .. vim.fn.fnameescape(corpus.directory()))
+        end
         if corpus.in_directory() then
           set_up_mappings()
           local width = math.floor(vim.o.columns / 2)


### PR DESCRIPTION
Closes #78 

Adds support to cd into a directory if Corpus is not currently in one and only has one configured. Not sure if it makes sense to set `num_dirs` on init or where it currently is on each call to `cmdline_changed`. Can move it if you'd like it elsewhere.